### PR TITLE
fix insufficient name warning

### DIFF
--- a/Adafruit_LSM303DLH_Mag.cpp
+++ b/Adafruit_LSM303DLH_Mag.cpp
@@ -318,7 +318,7 @@ void Adafruit_LSM303DLH_Mag_Unified::getSensor(sensor_t *sensor) {
   memset(sensor, 0, sizeof(sensor_t));
 
   /* Insert the sensor name in the fixed length char array */
-  strncpy(sensor->name, "LSM303DLH Mag", sizeof(sensor->name) - 1);
+  strncpy(sensor->name, "LSM303 Mag", sizeof(sensor->name) - 1);
   sensor->name[sizeof(sensor->name) - 1] = 0;
   sensor->version = 1;
   sensor->sensor_id = _sensorID;


### PR DESCRIPTION
sensor name is capped at 11 chars max 
- https://github.com/adafruit/Adafruit_Sensor/blob/master/Adafruit_Sensor.h#L147

"LSM303DLH Mag" is 13 bytes longs, 2 bytes need to be truncated. It is better for us to do the truncation than compiler, Let me know if you have better name in your mind